### PR TITLE
Migrate from JuliaFormatter to Runic

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,0 @@
-style = "sciml"

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# style: format codebase with Runic
+8e03c184f7fdcc7091d37c1e07a6fe07e92a348e

--- a/.github/workflows/Runic.yml
+++ b/.github/workflows/Runic.yml
@@ -1,0 +1,21 @@
+name: Runic
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  runic:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: "1"

--- a/examples/heat_box3d-linsolve.jl
+++ b/examples/heat_box3d-linsolve.jl
@@ -129,7 +129,7 @@ end
 
 # iterative solve using Simulation API
 dt = 0.001 * (ustrip(Δ))^2 / α
-sim = Simulation(domain, Transient(Δt=dt, stop_time=3.0e-4))
+sim = Simulation(domain, Transient(Δt = dt, stop_time = 3.0e-4))
 set!(sim, T = 0.0)
 @time run!(sim)
 T = temperature(sim)

--- a/src/models/time.jl
+++ b/src/models/time.jl
@@ -34,6 +34,6 @@ struct Transient{S} <: AbstractSimulationMode
     solver::S
 end
 
-function Transient(; Δt, stop_time, solver=Tsit5())
+function Transient(; Δt, stop_time, solver = Tsit5())
     return Transient(Float64(Δt), Float64(stop_time), solver)
 end

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -33,7 +33,7 @@ mutable struct Simulation{M, C, Mode <: AbstractSimulationMode}
     _solution::Union{Nothing, Vector{Float64}}
 end
 
-function Simulation(domain::Domain{M, C}, mode::AbstractSimulationMode=Steady()) where {M, C}
+function Simulation(domain::Domain{M, C}, mode::AbstractSimulationMode = Steady()) where {M, C}
     return Simulation{M, C, typeof(mode)}(domain, mode, nothing, 0.0, false, nothing)
 end
 
@@ -61,7 +61,7 @@ function _run!(sim::Simulation, mode::Transient; kwargs...)
     prob = _create_ode_problem(sim.domain, sim.u0, tspan)
     sol = OrdinaryDiffEq.solve(
         prob, mode.solver;
-        dt=mode.Δt, save_everystep=false, save_end=true, kwargs...
+        dt = mode.Δt, save_everystep = false, save_end = true, kwargs...
     )
     sim._solution = copy(sol.u[end])
     sim.time = sol.t[end]


### PR DESCRIPTION
## Summary
- Remove `.JuliaFormatter.toml` (SciML style) and format the entire codebase with Runic
- Add CI workflow (`.github/workflows/Runic.yml`) to enforce formatting on push/PR
- Add `.git-blame-ignore-revs` so `git blame` skips the bulk formatting commit

Closes #43

## Test plan
- [ ] `julia -e 'using Runic; Runic.main(["--check", "."])'` passes with no diffs
- [ ] Runic CI workflow runs and passes on this PR
- [ ] Existing tests still pass