### PR TITLE
chore(ci): add julia 1.10 to test matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.10'
           - '1.11'
           - '1.12'
         os:


### PR DESCRIPTION
Adds Julia 1.10 (LTS) to the test matrix so we cover 1.10/1.11/1.12 on ubuntu-latest.